### PR TITLE
fixed typo in graph defintions

### DIFF
--- a/graphs/ubiquiti-graph.properties
+++ b/graphs/ubiquiti-graph.properties
@@ -267,7 +267,7 @@ report.ubntAirMaxTable.ubntAirMaxAirtime.command=--title="AirMax Protocol Statis
 report.ubntStaTable.ubntStaSignal.name=UBNT-AirMAX-MIB::ubntStaTable::ubntStaSignal
 report.ubntStaTable.ubntStaSignal.columns=ubntStaSignal
 report.ubntStaTable.ubntStaSignal.type=ubntStaEntry
-report.ubntStaTable.propertiesValues=ubntStaName
+report.ubntStaTable.ubntStaSignal.propertiesValues=ubntStaName
 report.ubntStaTable.ubntStaSignal.description=Signal strength, dBm
 report.ubntStaTable.ubntStaSignal.command=--title="Station List: Signal" \
 --vertical-label="dBm" \
@@ -280,7 +280,7 @@ report.ubntStaTable.ubntStaSignal.command=--title="Station List: Signal" \
 report.ubntStaTable.ubntStaNoiseFloor.name=UBNT-AirMAX-MIB::ubntStaTable::ubntStaNoiseFloor
 report.ubntStaTable.ubntStaNoiseFloor.columns=ubntStaNoiseFloor
 report.ubntStaTable.ubntStaNoiseFloor.type=ubntStaEntry
-report.ubntStaTable.propertiesValues=ubntStaName
+report.ubntStaTable.ubntStaNoiseFloor.propertiesValues=ubntStaName
 report.ubntStaTable.ubntStaNoiseFloor.description=Noise floor
 report.ubntStaTable.ubntStaNoiseFloor.command=--title="Station List: NoiseFloor" \
  DEF:var={rrd1}:ubntStaNoiseFloor:AVERAGE \
@@ -292,7 +292,7 @@ report.ubntStaTable.ubntStaNoiseFloor.command=--title="Station List: NoiseFloor"
 report.ubntStaTable.ubntStaDistance.name=UBNT-AirMAX-MIB::ubntStaTable::ubntStaDistance
 report.ubntStaTable.ubntStaDistance.columns=ubntStaDistance
 report.ubntStaTable.ubntStaDistance.type=ubntStaEntry
-report.ubntStaTable.propertiesValues=ubntStaName
+report.ubntStaTable.ubntStaDistance.propertiesValues=ubntStaName
 report.ubntStaTable.ubntStaDistance.description=Distance
 report.ubntStaTable.ubntStaDistance.command=--title="Station List: Distance" \
  DEF:var={rrd1}:ubntStaDistance:AVERAGE \
@@ -304,7 +304,7 @@ report.ubntStaTable.ubntStaDistance.command=--title="Station List: Distance" \
 report.ubntStaTable.ubntStaCcq.name=UBNT-AirMAX-MIB::ubntStaTable::ubntStaCcq
 report.ubntStaTable.ubntStaCcq.columns=ubntStaCcq
 report.ubntStaTable.ubntStaCcq.type=ubntStaEntry
-report.ubntStaTable.propertiesValues=ubntStaName
+report.ubntStaTable.ubntStaCcq.propertiesValues=ubntStaName
 report.ubntStaTable.ubntStaCcq.description=CCQ in %
 report.ubntStaTable.ubntStaCcq.command=--title="Station List: CCQ" \
 --vertical-label="Percent" \
@@ -317,7 +317,7 @@ report.ubntStaTable.ubntStaCcq.command=--title="Station List: CCQ" \
 report.ubntStaTable.ubntStaAmp.name=UBNT-AirMAX-MIB::ubntStaTable::ubntStaAmp
 report.ubntStaTable.ubntStaAmp.columns=ubntStaAmp
 report.ubntStaTable.ubntStaAmp.type=ubntStaEntry
-report.ubntStaTable.propertiesValues=ubntStaName
+report.ubntStaTable.ubntStaAmp.propertiesValues=ubntStaName
 report.ubntStaTable.ubntStaAmp.description=airMAX priority
 report.ubntStaTable.ubntStaAmp.command=--title="Station List: AirMax Priority" \
  DEF:var={rrd1}:ubntStaAmp:AVERAGE \
@@ -329,7 +329,7 @@ report.ubntStaTable.ubntStaAmp.command=--title="Station List: AirMax Priority" \
 report.ubntStaTable.ubntStaAmq.name=UBNT-AirMAX-MIB::ubntStaTable::ubntStaAmq
 report.ubntStaTable.ubntStaAmq.columns=ubntStaAmq
 report.ubntStaTable.ubntStaAmq.type=ubntStaEntry
-report.ubntStaTable.propertiesValues=ubntStaName
+report.ubntStaTable.ubntStaAmq.propertiesValues=ubntStaName
 report.ubntStaTable.ubntStaAmq.description=airMAX quality
 report.ubntStaTable.ubntStaAmq.command=--title="Station List: AirMax Quality" \
  DEF:var={rrd1}:ubntStaAmq:AVERAGE \
@@ -341,7 +341,7 @@ report.ubntStaTable.ubntStaAmq.command=--title="Station List: AirMax Quality" \
 report.ubntStaTable.ubntStaAmc.name=UBNT-AirMAX-MIB::ubntStaTable::ubntStaAmc
 report.ubntStaTable.ubntStaAmc.columns=ubntStaAmc
 report.ubntStaTable.ubntStaAmc.type=ubntStaEntry
-report.ubntStaTable.propertiesValues=ubntStaName
+report.ubntStaTable.ubntStaAmc.propertiesValues=ubntStaName
 report.ubntStaTable.ubntStaAmc.description=airMAX capacity
 report.ubntStaTable.ubntStaAmc.command=--title="Station List: AirMax Capacity" \
  DEF:var={rrd1}:ubntStaAmc:AVERAGE \
@@ -353,7 +353,7 @@ report.ubntStaTable.ubntStaAmc.command=--title="Station List: AirMax Capacity" \
 report.ubntStaTable.ubntStaRate.name=UBNT-AirMAX-MIB::ubntStaTable::ubntStaRate
 report.ubntStaTable.ubntStaRate.columns=ubntStaTxRate,ubntStaRxRate
 report.ubntStaTable.ubntStaRate.type=ubntStaEntry
-report.ubntStaTable.propertiesValues=ubntStaName
+report.ubntStaTable.ubntStaRate.propertiesValues=ubntStaName
 report.ubntStaTable.ubntStaRate.description=TX/RX rate
 report.ubntStaTable.ubntStaRate.command=--title="Station List: RX/TX Rates" \
  DEF:var1={rrd1}:ubntStaTxRate:AVERAGE \
@@ -370,7 +370,7 @@ report.ubntStaTable.ubntStaRate.command=--title="Station List: RX/TX Rates" \
 report.ubntStaTable.ubntStaBytes.name=UBNT-AirMAX-MIB::ubntStaTable::ubntStaBytes
 report.ubntStaTable.ubntStaBytes.columns=ubntStaTxBytes,ubntStaRxBytes
 report.ubntStaTable.ubntStaBytes.type=ubntStaEntry
-report.ubntStaTable.propertiesValues=ubntStaName
+report.ubntStaTable.ubntStaBytes.propertiesValues=ubntStaName
 report.ubntStaTable.ubntStaBytes.description=TX/RX bytes
 report.ubntStaTable.ubntStaBytes.command=--title="Station List: RX/TX Bytes" \
 --vertical-label="Bytes" \
@@ -388,7 +388,7 @@ report.ubntStaTable.ubntStaBytes.command=--title="Station List: RX/TX Bytes" \
 report.ubntStaTable.ubntStaConnTime.name=UBNT-AirMAX-MIB::ubntStaTable::ubntStaConnTime
 report.ubntStaTable.ubntStaConnTime.columns=ubntStaConnTime
 report.ubntStaTable.ubntStaConnTime.type=ubntStaEntry
-report.ubntStaTable.propertiesValues=ubntStaName
+report.ubntStaTable.ubntStaConnTime.propertiesValues=ubntStaName
 report.ubntStaTable.ubntStaConnTime.description=Connection Time
 report.ubntStaTable.ubntStaConnTime.command=--title="Station List: Connection Time" \
 --vertical-label="Days" \
@@ -402,7 +402,7 @@ report.ubntStaTable.ubntStaConnTime.command=--title="Station List: Connection Ti
 report.ubntStaTable.ubntStaLocalCINR.name=UBNT-AirMAX-MIB::ubntStaTable::ubntStaLocalCINR
 report.ubntStaTable.ubntStaLocalCINR.columns=ubntStaLocalCINR
 report.ubntStaTable.ubntStaLocalCINR.type=ubntStaEntry
-report.ubntStaTable.propertiesValues=ubntStaName
+report.ubntStaTable.ubntStaLocalCINR.propertiesValues=ubntStaName
 report.ubntStaTable.ubntStaLocalCINR.description=Local carrier-to-noise ratio 
 report.ubntStaTable.ubntStaLocalCINR.command=--title="Station List: CINR" \
  DEF:var={rrd1}:ubntStaLocalCINR:AVERAGE \
@@ -414,7 +414,7 @@ report.ubntStaTable.ubntStaLocalCINR.command=--title="Station List: CINR" \
 report.ubntStaTable.ubntStaCapacity.name=UBNT-AirMAX-MIB::ubntStaTable::ubntStaTxCapacity
 report.ubntStaTable.ubntStaCapacity.columns=ubntStaTxCapacity,ubntStaRxCapacity
 report.ubntStaTable.ubntStaCapacity.type=ubntStaEntry
-report.ubntStaTable.propertiesValues=ubntStaName
+report.ubntStaTable.ubntStaCapacity.propertiesValues=ubntStaName
 report.ubntStaTable.ubntStaCapacity.description=Up/Downlink Capacity in Kbps
 report.ubntStaTable.ubntStaCapacity.command=--title="Station List RX/TX Capacity" \
  DEF:var1={rrd1}:ubntStaTxCapacity:AVERAGE \
@@ -431,7 +431,7 @@ report.ubntStaTable.ubntStaCapacity.command=--title="Station List RX/TX Capacity
 report.ubntStaTable.ubntStaAirtime.name=UBNT-AirMAX-MIB::ubntStaTable::ubntStaAirtime
 report.ubntStaTable.ubntStaAirtime.columns=ubntStaTxAirtime,ubntStaRxAirtime
 report.ubntStaTable.ubntStaAirtime.type=ubntStaEntry
-report.ubntStaTable.propertiesValues=ubntStaName
+report.ubntStaTable.ubntStaAirtime.propertiesValues=ubntStaName
 report.ubntStaTable.ubntStaAirtime.description=Down/Uplink Airtime in % multiplied by 10
 report.ubntStaTable.ubntStaAirtime.command=--title="Station List: RX/TX Airtime" \
  DEF:var1={rrd1}:ubntStaTxAirtime:AVERAGE \
@@ -448,8 +448,7 @@ report.ubntStaTable.ubntStaAirtime.command=--title="Station List: RX/TX Airtime"
 report.ubntStaTable.ubntStaTxLatency.name=UBNT-AirMAX-MIB::ubntStaTable::ubntStaTxLatency
 report.ubntStaTable.ubntStaTxLatency.columns=ubntStaTxLatency
 report.ubntStaTable.ubntStaTxLatency.type=ubntStaEntry
-report.ubntStaTable.propertiesValues=ubntStaName
-report.ubntStaTable.propertiesValues=ubntStaName
+report.ubntStaTable.ubntStaTxLatency.propertiesValues=ubntStaName
 report.ubntStaTable.ubntStaTxLatency.description=Uplink Latency in milliseconds
 report.ubntStaTable.ubntStaTxLatency.command=--title="Station List: Uplink Latency" \
  DEF:var={rrd1}:ubntStaTxLatency:AVERAGE \

--- a/graphs/ubiquiti-graph.properties
+++ b/graphs/ubiquiti-graph.properties
@@ -367,12 +367,12 @@ report.ubntStaTable.ubntStaRate.command=--title="Station List: RX/TX Rates" \
  GPRINT:var2:MIN:"Min\\: %8.2lf %s" \
  GPRINT:var2:MAX:"Max\\: %8.2lf %s\\n"
 
-report.ubntStaTable.ubntStaTxBytes.name=UBNT-AirMAX-MIB::ubntStaTable::ubntStaTxBytes
-report.ubntStaTable.ubntStaTxBytes.columns=ubntStaTxBytes,ubntStaRxBytes
-report.ubntStaTable.ubntStaTxBytes.type=ubntStaEntry
+report.ubntStaTable.ubntStaBytes.name=UBNT-AirMAX-MIB::ubntStaTable::ubntStaBytes
+report.ubntStaTable.ubntStaBytes.columns=ubntStaTxBytes,ubntStaRxBytes
+report.ubntStaTable.ubntStaBytes.type=ubntStaEntry
 report.ubntStaTable.propertiesValues=ubntStaName
-report.ubntStaTable.ubntStaTxBytes.description=TX/RX bytes
-report.ubntStaTable.ubntStaTxBytes.command=--title="Station List: RX/TX Bytes" \
+report.ubntStaTable.ubntStaBytes.description=TX/RX bytes
+report.ubntStaTable.ubntStaBytes.command=--title="Station List: RX/TX Bytes" \
 --vertical-label="Bytes" \
  DEF:var1={rrd1}:ubntStaTxBytes:AVERAGE \
  DEF:var2={rrd2}:ubntStaRxBytes:AVERAGE \
@@ -428,12 +428,12 @@ report.ubntStaTable.ubntStaCapacity.command=--title="Station List RX/TX Capacity
  GPRINT:var2:MIN:"Min\\: %8.2lf %s" \
  GPRINT:var2:MAX:"Max\\: %8.2lf %s\\n"
  
-report.ubntStaTable.ubntStaTxAirtime.name=UBNT-AirMAX-MIB::ubntStaTable::ubntStaTxAirtime
-report.ubntStaTable.ubntStaTxAirtime.columns=ubntStaTxAirtime,ubntStaRxAirtime
-report.ubntStaTable.ubntStaTxAirtime.type=ubntStaEntry
+report.ubntStaTable.ubntStaAirtime.name=UBNT-AirMAX-MIB::ubntStaTable::ubntStaAirtime
+report.ubntStaTable.ubntStaAirtime.columns=ubntStaTxAirtime,ubntStaRxAirtime
+report.ubntStaTable.ubntStaAirtime.type=ubntStaEntry
 report.ubntStaTable.propertiesValues=ubntStaName
-report.ubntStaTable.ubntStaTxAirtime.description=Down/Uplink Airtime in % multiplied by 10
-report.ubntStaTable.ubntStaTxAirtime.command=--title="Station List: RX/TX Airtime" \
+report.ubntStaTable.ubntStaAirtime.description=Down/Uplink Airtime in % multiplied by 10
+report.ubntStaTable.ubntStaAirtime.command=--title="Station List: RX/TX Airtime" \
  DEF:var1={rrd1}:ubntStaTxAirtime:AVERAGE \
  DEF:var2={rrd2}:ubntStaRxAirtime:AVERAGE \
  LINE1:var1#00ccff:"Transmit" \


### PR DESCRIPTION
There was a report name mismatch, so OpenNMS always complained about it while starting.