### PR TITLE
Fix datasource references

### DIFF
--- a/grafana/ubiquiti-airmax.json
+++ b/grafana/ubiquiti-airmax.json
@@ -1124,7 +1124,7 @@
             "rgb(119, 119, 119)",
             "rgb(119, 119, 119)"
           ],
-          "datasource": "OpenNMS Performance",
+          "datasource": "${DS_OPENNMS_PERFORMANCE}",
           "format": "none",
           "gauge": {
             "maxValue": 100,
@@ -1251,7 +1251,7 @@
             "rgb(119, 119, 119)",
             "rgb(119, 119, 119)"
           ],
-          "datasource": "OpenNMS Performance",
+          "datasource": "${DS_OPENNMS_PERFORMANCE}",
           "format": "none",
           "gauge": {
             "maxValue": 100,
@@ -1379,7 +1379,7 @@
             "rgb(119, 119, 119)",
             "rgb(119, 119, 119)"
           ],
-          "datasource": "OpenNMS Performance",
+          "datasource": "${DS_OPENNMS_PERFORMANCE}",
           "format": "none",
           "gauge": {
             "maxValue": 100,
@@ -1506,7 +1506,7 @@
             "rgb(119, 119, 119)",
             "rgb(119, 119, 119)"
           ],
-          "datasource": "OpenNMS Performance",
+          "datasource": "${DS_OPENNMS_PERFORMANCE}",
           "format": "none",
           "gauge": {
             "maxValue": 100,
@@ -1633,7 +1633,7 @@
             "#5195ce",
             "rgb(119, 119, 119)"
           ],
-          "datasource": "OpenNMS Performance",
+          "datasource": "${DS_OPENNMS_PERFORMANCE}",
           "format": "none",
           "gauge": {
             "maxValue": 100,
@@ -1765,7 +1765,7 @@
             "rgb(119, 119, 119)",
             "rgb(119, 119, 119)"
           ],
-          "datasource": "OpenNMS Performance",
+          "datasource": "${DS_OPENNMS_PERFORMANCE}",
           "format": "none",
           "gauge": {
             "maxValue": 100,
@@ -1892,7 +1892,7 @@
             "rgb(119, 119, 119)",
             "rgb(119, 119, 119)"
           ],
-          "datasource": "OpenNMS Performance",
+          "datasource": "${DS_OPENNMS_PERFORMANCE}",
           "format": "none",
           "gauge": {
             "maxValue": 100,
@@ -2019,7 +2019,7 @@
             "rgb(119, 119, 119)",
             "rgb(119, 119, 119)"
           ],
-          "datasource": "OpenNMS Performance",
+          "datasource": "${DS_OPENNMS_PERFORMANCE}",
           "format": "none",
           "gauge": {
             "maxValue": 100,
@@ -2146,7 +2146,7 @@
             "rgb(119, 119, 119)",
             "rgb(119, 119, 119)"
           ],
-          "datasource": "OpenNMS Performance",
+          "datasource": "${DS_OPENNMS_PERFORMANCE}",
           "format": "none",
           "gauge": {
             "maxValue": 100,
@@ -2284,7 +2284,7 @@
           "bars": false,
           "dashLength": 10,
           "dashes": false,
-          "datasource": "OpenNMS Performance",
+          "datasource": "${DS_OPENNMS_PERFORMANCE}",
           "fill": 1,
           "gridPos": {
             "h": 10,
@@ -2427,7 +2427,7 @@
           "bars": false,
           "dashLength": 10,
           "dashes": false,
-          "datasource": "OpenNMS Performance",
+          "datasource": "${DS_OPENNMS_PERFORMANCE}",
           "fill": 1,
           "gridPos": {
             "h": 10,
@@ -2586,7 +2586,7 @@
           "bars": false,
           "dashLength": 10,
           "dashes": false,
-          "datasource": "OpenNMS Performance",
+          "datasource": "${DS_OPENNMS_PERFORMANCE}",
           "fill": 1,
           "gridPos": {
             "h": 10,
@@ -2739,7 +2739,7 @@
           "bars": false,
           "dashLength": 10,
           "dashes": false,
-          "datasource": "OpenNMS Performance",
+          "datasource": "${DS_OPENNMS_PERFORMANCE}",
           "fill": 1,
           "gridPos": {
             "h": 10,
@@ -2910,7 +2910,7 @@
           "bars": false,
           "dashLength": 10,
           "dashes": false,
-          "datasource": "OpenNMS Performance",
+          "datasource": "${DS_OPENNMS_PERFORMANCE}",
           "fill": 1,
           "gridPos": {
             "h": 10,
@@ -3050,7 +3050,7 @@
           "bars": false,
           "dashLength": 10,
           "dashes": false,
-          "datasource": "OpenNMS Performance",
+          "datasource": "${DS_OPENNMS_PERFORMANCE}",
           "fill": 1,
           "gridPos": {
             "h": 10,
@@ -3170,7 +3170,7 @@
           "bars": false,
           "dashLength": 10,
           "dashes": false,
-          "datasource": "OpenNMS Performance",
+          "datasource": "${DS_OPENNMS_PERFORMANCE}",
           "fill": 1,
           "gridPos": {
             "h": 10,
@@ -3312,7 +3312,7 @@
           "bars": false,
           "dashLength": 10,
           "dashes": false,
-          "datasource": "OpenNMS Performance",
+          "datasource": "${DS_OPENNMS_PERFORMANCE}",
           "fill": 1,
           "gridPos": {
             "h": 10,
@@ -3431,7 +3431,7 @@
           "bars": false,
           "dashLength": 10,
           "dashes": false,
-          "datasource": "OpenNMS Performance",
+          "datasource": "${DS_OPENNMS_PERFORMANCE}",
           "fill": 1,
           "gridPos": {
             "h": 10,
@@ -3558,7 +3558,7 @@
           "bars": false,
           "dashLength": 10,
           "dashes": false,
-          "datasource": "OpenNMS Performance",
+          "datasource": "${DS_OPENNMS_PERFORMANCE}",
           "fill": 1,
           "gridPos": {
             "h": 10,
@@ -3705,7 +3705,7 @@
           "bars": false,
           "dashLength": 10,
           "dashes": false,
-          "datasource": "OpenNMS Performance",
+          "datasource": "${DS_OPENNMS_PERFORMANCE}",
           "fill": 1,
           "gridPos": {
             "h": 8,
@@ -3841,7 +3841,7 @@
           "bars": false,
           "dashLength": 10,
           "dashes": false,
-          "datasource": "OpenNMS Performance",
+          "datasource": "${DS_OPENNMS_PERFORMANCE}",
           "fill": 1,
           "gridPos": {
             "h": 8,
@@ -3973,7 +3973,7 @@
           "bars": false,
           "dashLength": 10,
           "dashes": false,
-          "datasource": "OpenNMS Performance",
+          "datasource": "${DS_OPENNMS_PERFORMANCE}",
           "fill": 1,
           "gridPos": {
             "h": 8,
@@ -4109,7 +4109,7 @@
             "rgba(237, 129, 40, 0.89)",
             "#d44a3a"
           ],
-          "datasource": "OpenNMS Performance",
+          "datasource": "${DS_OPENNMS_PERFORMANCE}",
           "decimals": null,
           "format": "lengthm",
           "gauge": {
@@ -4224,7 +4224,7 @@
           "bars": false,
           "dashLength": 10,
           "dashes": false,
-          "datasource": "OpenNMS Performance",
+          "datasource": "${DS_OPENNMS_PERFORMANCE}",
           "fill": 1,
           "gridPos": {
             "h": 8,
@@ -4366,7 +4366,7 @@
           "bars": false,
           "dashLength": 10,
           "dashes": false,
-          "datasource": "OpenNMS Performance",
+          "datasource": "${DS_OPENNMS_PERFORMANCE}",
           "fill": 1,
           "gridPos": {
             "h": 8,
@@ -4486,7 +4486,7 @@
           "bars": false,
           "dashLength": 10,
           "dashes": false,
-          "datasource": "OpenNMS Performance",
+          "datasource": "${DS_OPENNMS_PERFORMANCE}",
           "fill": 1,
           "gridPos": {
             "h": 8,
@@ -4637,7 +4637,7 @@
             "rgba(237, 129, 40, 0.89)",
             "#d44a3a"
           ],
-          "datasource": "OpenNMS Performance",
+          "datasource": "${DS_OPENNMS_PERFORMANCE}",
           "decimals": null,
           "format": "s",
           "gauge": {


### PR DESCRIPTION
Not all panel datasources were set to use the variable, and therefore were hard-coded to specific source names.  This standardizes them so that when importing them, it will match the user's Grafana datasource name.